### PR TITLE
Do not run unit tests during RPM build

### DIFF
--- a/python-crane.spec
+++ b/python-crane.spec
@@ -17,8 +17,6 @@ BuildArch: noarch
 
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
-BuildRequires: python-mock
-BuildRequires: python-unittest2
 
 Requires: python-flask >= 0.9
 Requires: python-setuptools
@@ -35,10 +33,6 @@ settings.
 
 %prep
 %setup -q -n %{name}-%{version}
-
-
-%check
-%{__python2} setup.py test
 
 
 %build


### PR DESCRIPTION
The unit tests depend on external network connectivity to pull down some test
packages outside of RPM deps. This is not allowed in Koji.

The tests run via Travis anyway so this second run is not needed.
