### PR TITLE
the /v1/repositories/<repo_id>/images call now handles the default "library" namespace

### DIFF
--- a/crane/app_util.py
+++ b/crane/app_util.py
@@ -147,3 +147,28 @@ def get_data():
         request.crane_data = data.response_data
 
     return request.crane_data
+
+
+def validate_and_transform_repoid(repo_id):
+    """
+    Validates that the repo ID does not contain more than one slash, and removes
+    the default "library" namespace if present.
+
+    :param repo_id: unique ID for the repository. May contain 0 or 1 of the "/"
+                    character. For repo IDs that do not contain a slash, the
+                    docker client currently prepends "library/" when making
+                    this call. This function strips that off.
+    :type  repo_id: basestring
+
+    :return:    repo ID without the "library" namespace
+    :rtype:     basestring
+    """
+    # a valid repository ID will have zero or one slash
+    if len(repo_id.split('/')) > 2:
+        raise exceptions.HTTPError(httplib.NOT_FOUND)
+
+    # for repositories that do not have a "/" in the name, docker will add
+    # "library/" to the beginning of the repository path.
+    if repo_id.startswith('library/'):
+        return repo_id[len('library/'):]
+    return repo_id

--- a/crane/views/v1.py
+++ b/crane/views/v1.py
@@ -2,6 +2,7 @@ import httplib
 
 from flask import Blueprint, json, current_app, redirect, request
 
+from .. import app_util
 from .. import config
 from .. import exceptions
 from ..api import repository, images
@@ -62,9 +63,7 @@ def repo_images(repo_id):
     :return:    json string containing a list of image IDs
     :rtype:     basestring
     """
-    # a valid repository ID will have zero or one slash
-    if len(repo_id.split('/')) > 2:
-        raise exceptions.HTTPError(httplib.NOT_FOUND)
+    repo_id = app_util.validate_and_transform_repoid(repo_id)
 
     images_in_repo = repository.get_images_for_repo(repo_id)
     response = current_app.make_response(images_in_repo)
@@ -90,14 +89,7 @@ def repo_tags(repo_id):
     :return:    json string containing an object mapping tag names to image IDs
     :rtype:     basestring
     """
-    # a valid repository ID will have zero or one slash
-    if len(repo_id.split('/')) > 2:
-        raise exceptions.HTTPError(httplib.NOT_FOUND)
-
-    # for repositories that do not have a "/" in the name, docker will add
-    # "library/" to the beginning of the repository path only for this call.
-    if repo_id.startswith('library/'):
-        repo_id = repo_id[len('library/'):]
+    repo_id = app_util.validate_and_transform_repoid(repo_id)
 
     return repository.get_tags_for_repo(repo_id)
 

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -1,12 +1,11 @@
 import httplib
-import unittest
 
 import mock
 from rhsm import certificate, certificate2
+import unittest2 as unittest
 
 from crane import app_util
 from crane import exceptions
-from crane.data import Repo
 import demo_data
 
 from .views import base
@@ -156,3 +155,20 @@ class TestGetCertificate(FlaskContextBase):
         self.ctx.request.environ['SSL_CLIENT_CERT'] = data
         cert = app_util._get_certificate()
         self.assertTrue(isinstance(cert, certificate2.EntitlementCertificate))
+
+
+class TestValidateAndTransformRepoID(unittest.TestCase):
+    def test_more_than_one_slash(self):
+        with self.assertRaises(exceptions.HTTPError) as assertion:
+            app_util.validate_and_transform_repoid('a/b/c')
+        self.assertEqual(assertion.exception.status_code, httplib.NOT_FOUND)
+
+    def test_library_namespace(self):
+        ret = app_util.validate_and_transform_repoid('library/centos')
+
+        self.assertEqual(ret, 'centos')
+
+    def test_normal(self):
+        ret = app_util.validate_and_transform_repoid('foo/bar')
+
+        self.assertEqual(ret, 'foo/bar')

--- a/tests/views/test_repositories.py
+++ b/tests/views/test_repositories.py
@@ -46,6 +46,21 @@ class TestRepository(base.BaseCraneAPITest):
         response_data = json.loads(response.data)
         self.assertTrue({'id': 'def456'} in response_data)
 
+    def test_images_no_namespace_docker_1_3_plus(self):
+        """
+        The "bar" repository ID does not have a namespace
+        """
+        response = self.test_client.get('/v1/repositories/library/bar/images')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json')
+        self.assertEqual(response.headers['X-Docker-Registry-Config'], 'common')
+        self.assertEqual(response.headers['X-Docker-Registry-Version'], '0.6.6')
+        self.assertEqual(response.headers['X-Docker-Endpoints'], 'localhost:5000')
+
+        response_data = json.loads(response.data)
+        self.assertTrue({'id': 'def456'} in response_data)
+
     def test_images_404(self):
         response = self.test_client.get('/v1/repositories/idontexist/images')
 


### PR DESCRIPTION
Docker 1.2 and earlier did not add the default "library" namespace to this
call. That changed with 1.3, thus we had to adjust the handler.
