### PR TITLE
Use the data file's version to determine where to put repo data.

### DIFF
--- a/crane/data.py
+++ b/crane/data.py
@@ -135,7 +135,7 @@ def load_all(app):
         # load data from each file
         for metadata_file_path in paths:
             repo_id, repo_tuple, image_ids = load_from_file(metadata_file_path)
-            if image_ids:
+            if isinstance(repo_tuple, V1Repo):
                 v1_repos[repo_id] = repo_tuple
                 for image_id in image_ids:
                     images.setdefault(image_id, set()).add(repo_id)


### PR DESCRIPTION
This commit fixes a bug that caused Crane to sometimes redirect /v2/ requests to /v1/ publishes in Pulp.

https://pulp.plan.io/issues/1271

fixes #1271