### PR TITLE
Error response for V2 registry

### DIFF
--- a/tests/views/test_path.py
+++ b/tests/views/test_path.py
@@ -1,12 +1,17 @@
+import json
+
 from tests.views import base
 
 
 class TestPath(base.BaseCraneAPITest):
     def test_invalid_repo_name(self):
         response = self.test_client.get('/v2/no/name/test')
+        parsed_response_data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 404)
-        self.assertTrue(response.headers['Content-Type'].startswith('text/html'))
+        self.assertTrue(response.headers['Content-Type'].startswith('application/json'))
+        self.assertEqual(parsed_response_data['errors'][0]['code'], '404')
+        self.assertEqual(parsed_response_data['errors'][0]['message'], 'Not Found')
 
     def test_valid_repo_name_for_manifest(self):
         response = self.test_client.get('/v2/redhat/foo/manifests/2')
@@ -45,6 +50,9 @@ class TestPath(base.BaseCraneAPITest):
 
     def test_repo_name_without_manifest_or_tags_or_blobs(self):
         response = self.test_client.get('/v2/foo/test')
+        parsed_response_data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 404)
-        self.assertTrue(response.headers['Content-Type'].startswith('text/html'))
+        self.assertTrue(response.headers['Content-Type'].startswith('application/json'))
+        self.assertEqual(parsed_response_data['errors'][0]['code'], '404')
+        self.assertEqual(parsed_response_data['errors'][0]['message'], 'Not Found')


### PR DESCRIPTION
The docker looks for a specific format when parsing V2 error response. This PR implements the error response  JSON format as required by V2 spec (https://docs.docker.com/registry/spec/api/) in the errors section. The change only effects the V2 error response. V1 response is same as before.