### PR TITLE
Issue #1294: Can't sync b/n 2 pulps: Changes for tags/list endpoint

### DIFF
--- a/tests/views/test_path.py
+++ b/tests/views/test_path.py
@@ -1,4 +1,5 @@
 import json
+import mock
 
 from tests.views import base
 
@@ -20,12 +21,17 @@ class TestPath(base.BaseCraneAPITest):
         self.assertTrue(response.headers['Content-Type'].startswith('text/html'))
         self.assertTrue('foo/bar/manifests/2' in response.headers['Location'])
 
-    def test_valid_repo_name_for_tags(self):
-        response = self.test_client.get('/v2/redhat/foo/tags/latest')
+    @mock.patch('urllib2.urlopen')
+    def test_valid_repo_name_for_tags(self, mock_urlopen):
+        mocked_response = mock.Mock()
+        mocked_response.read.side_effect = ['{"tag": "test"}']
+        mock_urlopen.return_value = mocked_response
+        response = self.test_client.get('/v2/redhat/foo/tags/list')
+        parsed_response_data = json.loads(response.data)
 
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.headers['Content-Type'].startswith('text/html'))
-        self.assertTrue('foo/bar/tags/latest' in response.headers['Location'])
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.headers['Content-Type'].startswith('application/json'))
+        self.assertTrue('test' in parsed_response_data.get('tags').get('tag'))
 
     def test_valid_repo_name_for_blobs(self):
         response = self.test_client.get('/v2/redhat/foo/blobs/123')
@@ -50,6 +56,15 @@ class TestPath(base.BaseCraneAPITest):
 
     def test_repo_name_without_manifest_or_tags_or_blobs(self):
         response = self.test_client.get('/v2/foo/test')
+        parsed_response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(response.headers['Content-Type'].startswith('application/json'))
+        self.assertEqual(parsed_response_data['errors'][0]['code'], '404')
+        self.assertEqual(parsed_response_data['errors'][0]['message'], 'Not Found')
+
+    def test_repo_name_without_tags_list(self):
+        response = self.test_client.get('/v2/foo/tags/tag')
         parsed_response_data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
This PR resolves pulp-to-pulp sync issue described in https://pulp.plan.io/issues/1294. This provides the following:
* Redirects for manifests and blobs request.
* Retrieves tags if request is for tags/list and adds the tags to the body rather than redirect.

This PR is based on a patch provided by Jindrich Luza
