### PR TITLE
Issue #1294: Can't sync b/n 2 pulps - Manifest related changes

### DIFF
--- a/crane/api/repository.py
+++ b/crane/api/repository.py
@@ -30,6 +30,20 @@ def get_tags_for_repo(repo_id):
 
 
 @authorize_name
+def get_v2_tags_for_repo(repo_id):
+    """
+    Return the tag details for a repository
+
+    :param repo_id: The identifier for the repository
+    :type repo_id: basestring
+    :returns: json structure of repo tags
+    :rtype: dict
+    """
+    # Validation that the repo exists is taken care of by the decorator
+    return get_v2_data()['repos'][repo_id].tags_json
+
+
+@authorize_name
 def get_path_for_repo(repo_id):
     """
     Return the URL for the repository.

--- a/crane/data.py
+++ b/crane/data.py
@@ -22,7 +22,7 @@ v2_response_data = {
 }
 
 V1Repo = namedtuple('V1Repo', ['url', 'images_json', 'tags_json', 'url_path', 'protected'])
-V2Repo = namedtuple('V2Repo', ['url', 'url_path', 'protected'])
+V2Repo = namedtuple('V2Repo', ['url', 'url_path', 'protected', "tags_json"])
 
 
 def load_from_file(path):
@@ -59,7 +59,8 @@ def load_from_file(path):
         return repo_id, repo_tuple, image_ids
     elif repo_data['version'] == 2:
         repo_tuple = V2Repo(repo_data['url'],
-                            url_path, repo_data.get('protected', False))
+                            url_path, repo_data.get('protected', False),
+                            repo_data["tags"])
         return repo_id, repo_tuple, None
 
 

--- a/crane/views/v2.py
+++ b/crane/views/v2.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+from functools import partial
 import httplib
+import urllib2
+
 from flask import Blueprint, json, current_app, redirect
 
 from crane import app_util, exceptions
@@ -7,6 +10,119 @@ from crane.api import repository
 
 
 section = Blueprint('v2', __name__, url_prefix='/v2')
+
+
+def url_construct(name_component, path_component):
+    """
+    Returns the url for redirection based on name of the repo and
+    appending it with path provided by path_component
+
+    :param name_component: name of the repository
+    :type name_component: basestring
+
+    :param path_component: the relative path
+    :type path_component: basestring
+
+    :return: the complete url for redirection
+    :rtype: basestring
+    """
+    base_url = repository.get_path_for_repo(name_component)
+    if not base_url.endswith('/'):
+        base_url += '/'
+    url = base_url + path_component
+    return url
+
+
+def process_redirect(name, path):
+    """
+    Redirects the client to the path from where the file can be accessed.
+
+    :param name:    name of the repository. The combination of username and repo specifies
+                    a repo id
+    :type  name:    basestring
+
+    :param path: the relative path
+    :type path:  basestring
+
+    :return:    302 redirect response
+    :rtype:     flask.Response
+    """
+    url = url_construct(name, path)
+    return redirect(url)
+
+
+def process_response(name, path, post_process=None):
+    """
+    Process a response based on whether response is a simple
+    redirect or 200 OK with tags as body
+    :param name:    name of the repository. The combination of username and
+                    repo specifies a repo id
+    :type  name:    basestring
+
+    :param path: the relative path
+    :type path:  basestring
+
+    :param post_process: function to be called for post processing
+    :type post_process: function
+
+    :return: response
+    :rtype: flask.response
+    """
+    url = url_construct(name, path)
+    response = urllib2.urlopen(url, timeout=1).read()
+    if post_process:
+        response = post_process(response, extra={"name": name,
+                                                 "file_path": path})
+    return response
+
+
+def tag_list(response, extra=None):
+    """
+    Return JSON document containing list of tags
+    :param response: response to be processed
+    :type response: httplib.response
+
+    :param extra: dictionary containing values for name
+                  and relative path
+    :type extra:  dict
+
+    :return: response with JSON document having tags as body
+    :rtype: flask.response
+    """
+    tags = json.loads(response)
+    tags_wrap = {"name": extra["name"], "tags": tags}
+    return current_app.make_response(json.dumps(tags_wrap))
+
+
+def get_manifest(response, extra=None):
+    """
+    Adds the docker-content-digest header to the response
+    :param response: response to be processed
+    :type response: httplib.response
+
+    :param extra: dictionary containing values for name
+                  and relative path
+    :type extra:  dict
+
+    :return: response
+    :rtype: flask.response
+    """
+    reference = extra["file_path"].split("/")[1]
+    tags = repository.get_v2_tags_for_repo(extra["name"])
+    if reference in tags:
+        digest = tags[reference]
+    else:
+        digest = reference
+    response = current_app.make_response(response)
+    response.headers['Docker-Content-Digest'] = digest
+    return response
+
+
+READONLY_API = {"manifests/": partial(process_response,
+                                      post_process=get_manifest),
+                "blobs/": process_redirect,
+                "tags/list": partial(process_response,
+                                     post_process=tag_list)}
 
 
 @section.after_request
@@ -60,16 +176,15 @@ def name_redirect(name, file_path):
     :return:    302 redirect response
     :rtype:     flask.Response
     """
-
-    # name, repo_name, path = app_util.validate_and_transform_repo_name(username, repo, file_path)
     full_path = '/'.join([name, file_path])
-
     name_component, path_component = app_util.validate_and_transform_repo_name(full_path)
-    base_url = repository.get_path_for_repo(name_component)
-    if not base_url.endswith('/'):
-        base_url += '/'
-    url = base_url + path_component
-    return redirect(url)
+
+    if not any([value in path_component for value in READONLY_API.keys()]):
+        raise exceptions.HTTPError(httplib.NOT_FOUND)
+
+    for path_tmpl in READONLY_API:
+        if path_component.startswith(path_tmpl):
+            return READONLY_API[path_tmpl](name_component, path_component)
 
 
 @section.errorhandler(exceptions.HTTPError)

--- a/tests/data/metadata_good/bar_v2.json
+++ b/tests/data/metadata_good/bar_v2.json
@@ -1,6 +1,7 @@
 {    
     "repository": "v2bar",
     "repo-registry-id": "v2/bar",
+    "tags": {"tag1":"hash1", "tag2":"hash2"},
     "url": "http://cdn.redhat.com/bar/baz/images/",
     "version": 2
 }

--- a/tests/data/metadata_good/foo_v2.json
+++ b/tests/data/metadata_good/foo_v2.json
@@ -1,6 +1,7 @@
 {
     "repository": "foo",
     "repo-registry-id": "redhat/foo",
+    "tags": {"tag1":"hash1", "tag2":"hash2"},
     "url": "http://cdn.redhat.com/foo/bar",
     "version": 2
 }

--- a/tests/data/metadata_good/protected.json
+++ b/tests/data/metadata_good/protected.json
@@ -2,6 +2,7 @@
     "repository": "protected",
     "repo-registry-id": "protected",    
     "url": "http://cdn.redhat.com/bar/baz/images",
+    "tags": {"tag1":"hash1", "tag2":"hash2"},
     "version": 2,
     "protected": true
 }

--- a/tests/data/metadata_good/registry.json
+++ b/tests/data/metadata_good/registry.json
@@ -1,3 +1,3 @@
 {"repo-registry-id": "registry", "repository": "registry", "url":
-"https://oh-hey-beav-whats-up.os1.phx2.redhat.com/pulp/docker/v2/registry/",
+"https://oh-hey-beav-whats-up.os1.phx2.redhat.com/pulp/docker/v2/registry/", "tags": {"tag1":"hash1", "tag2":"hash2"},
 "version": 2, "protected": false, "type": "pulp-docker-redirect"}

--- a/tests/data/v2/metadata_good/bar.json
+++ b/tests/data/v2/metadata_good/bar.json
@@ -1,6 +1,7 @@
 {   
     "repository": "bar",
-    "repo-registry-id": "bar",    
+    "repo-registry-id": "bar",
+    "tags": {"tag1":"hash1", "tag2":"hash2"},
     "url": "http://cdn.redhat.com/bar/baz/images",
     "version": 2
 }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -85,6 +85,8 @@ class TestLoadAll(unittest.TestCase):
         # make sure the Repo namedtuple is in the right place
         self.assertTrue(isinstance(data.v2_response_data['repos'].get('bar'), data.V2Repo))
         # spot-check a value
+        self.assertEqual(data.v2_response_data['repos'].get('bar').tags_json,
+                         {'tag1': 'hash1', 'tag2': 'hash2'})
         self.assertEqual(data.v2_response_data['repos'].get('bar').url,
                          'http://cdn.redhat.com/bar/baz/images')
 


### PR DESCRIPTION
This PR  contains changes in patch for manifest related changes provided by __Jindrich Luza__. This PR is dependent on the patch for pulp that adds manifest hashes in redirect-file/metadata file. __If the corresponding patch/logic is not present at the pulp's end, applying this PR will cause metadata loading to abort__. 