### PR TITLE
Set the version requirement on mock to be less than 1.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ before_install:
  # Create a fake RPM package so that the python-rhsm certificate class will load properly
   - mkdir rpm
   - touch rpm/__init__.py
+  - .travis/install_m2crypto.sh
 install:
   - "pip install ."
   - "pip install -r test-requirements.txt"
-  - "pip install -r travis-requirements.txt"
+  - "pip install -r .travis/requirements.txt"
   - "pip install coveralls"
   - "pip install git+https://github.com/barnabycourt/python-rhsm.git"
 before_script:

--- a/.travis/install_m2crypto.sh
+++ b/.travis/install_m2crypto.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -xe
+
+# This is based on a suggestion in a github comment:
+# https://github.com/travis-ci/travis-ci/issues/721#issuecomment-17197098
+
+# openssl 1.0 does not have sslv2, which is not disabled in m2crypto
+# therefore this workaround is required
+
+PATCH="
+--- SWIG/_ssl.i   2015-11-03 15:54:40.942000000 -0500
++++ SWIG/_ssl.i   2015-11-03 15:55:17.810000000 -0500
+@@ -48,8 +48,10 @@
+ %rename(ssl_get_alert_desc_v) SSL_alert_desc_string_long;
+ extern const char *SSL_alert_desc_string_long(int);
+ 
++#ifndef OPENSSL_NO_SSL2
+ %rename(sslv2_method) SSLv2_method;
+ extern SSL_METHOD *SSLv2_method(void);
++#endif
+ %rename(sslv3_method) SSLv3_method;
+ extern SSL_METHOD *SSLv3_method(void);
+ %rename(sslv23_method) SSLv23_method;"
+
+pip install --download="." m2crypto==0.21.1
+tar -xf M2Crypto-*.tar.gz
+rm M2Crypto-*.tar.gz
+cd M2Crypto-*
+echo "$PATCH" | patch -p0
+python setup.py install
+cd ..
+# We need to clean up so that flake8 doesn't get upset.
+rm -rf M2Crypto-*

--- a/.travis/requirements.txt
+++ b/.travis/requirements.txt
@@ -1,4 +1,3 @@
 # Requirements that are specific to the travis build environment
 python-dateutil>=1.5
 iniparse>=0.3.1
-M2Crypto>=0.21.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coverage
 flake8
-mock
+mock<1.1
 nose
 unittest2


### PR DESCRIPTION
The Crane tests fail with Mock versions >= 1.1. This commit requires the dev environment to have a compatible
version.