### PR TITLE
Don't run selinux commands if selinux is disabled

### DIFF
--- a/python-crane.spec
+++ b/python-crane.spec
@@ -69,13 +69,17 @@ rm -rf %{buildroot}%{python2_sitelib}/tests
 
 
 %post
-semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-restorecon -R -v %{_var}/lib/crane
+if [ /usr/sbin/selinuxenabled -eq 0 ] ; then
+  semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
+  restorecon -R -v %{_var}/lib/crane
+fi
 
 %postun
 if [ $1 -eq 0 ] ; then  # final removal
-semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-restorecon -R -v %{_var}/lib/crane
+  if [ /usr/sbin/selinuxenabled -eq 0 ] ; then
+    semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
+    restorecon -R -v %{_var}/lib/crane
+  fi
 fi
 
 


### PR DESCRIPTION
Don't run selinux commands if selinux is disabled

closes #[1572](https://pulp.plan.io/issues/1572)
https://pulp.plan.io/issues/1572