### PR TITLE
Only restorecon if the /var/lib/crane exits

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Barnaby Court (bcourt@redhat.com)
 Michael Hrivnak (mhrivnak@redhat.com)
 Sayli Karmarkar (skarmark@redhat.com)
+Bryan Kearney (bryan.kearney@gmail.com)
 Dennis Kliban (dkliban@redhat.com)
 Aaron Weitekamp (aweiteka@redhat.com)
 A.P. Rajshekhar (randalap@redhat.com)

--- a/python-crane.spec
+++ b/python-crane.spec
@@ -70,15 +70,19 @@ rm -rf %{buildroot}%{python2_sitelib}/tests
 
 %post
 if /usr/sbin/selinuxenabled ; then
-  semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-  restorecon -R -v %{_var}/lib/crane
+  if [ -d "%{_var}/lib/crane" ]; then
+    semanage fcontext -a -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
+    restorecon -R -v %{_var}/lib/crane
+  fi
 fi
 
 %postun
 if [ $1 -eq 0 ] ; then  # final removal
   if /usr/sbin/selinuxenabled ; then
-    semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
-    restorecon -R -v %{_var}/lib/crane
+    if [ -d "%{_var}/lib/crane" ]; then
+      semanage fcontext -d -t httpd_sys_content_t '%{_var}/lib/crane(/.*)?'
+      restorecon -R -v %{_var}/lib/crane
+    fi
   fi
 fi
 


### PR DESCRIPTION
This is being reintroduced onto `2.0-dev`. It was originally reviewed with #62 then negative committed from master with #64.

https://pulp.plan.io/issues/1958
fixes #1958