### PR TITLE
- fixed missing followlinks=True in os.path.walk

### DIFF
--- a/crane/data.py
+++ b/crane/data.py
@@ -152,7 +152,8 @@ def load_all(app):
         logger.info('loading metadata from %s' % data_dir)
         # scan data dir recursively and pick json files
         paths = [os.path.join(dirpath, f)
-                 for dirpath, dirnames, files in os.walk(data_dir)
+                 for dirpath, dirnames, files in os.walk(data_dir,
+                                                         followlinks=True)
                  for f in fnmatch.filter(files, '*.json')]
 
         # load data from each file


### PR DESCRIPTION
In configuration when crane metadata_dir points to directory with symlinks to v1 and v2 app dirs,
missing  followlinks=True will prevents crane from loading json files in those nested directories
