### PR TITLE
Add endpoint /crane/repositories/v2 to display v2 repositories.

### DIFF
--- a/crane/app_util.py
+++ b/crane/app_util.py
@@ -172,7 +172,7 @@ def get_repositories():
     """
     Get the current data used for processing requests from the flask request context
     and format it to display basic information about image ids and tags associated
-    with each repository.
+    with each v1 repository.
 
     Value corresponding to each key(repo-registry-id) is a dictionary itself
     with the following format:
@@ -191,6 +191,26 @@ def get_repositories():
         relevant_repo_data[repo_registry_id] = {'image_ids': image_ids,
                                                 'tags': json.loads(repo.tags_json),
                                                 'protected': repo.protected}
+
+    return relevant_repo_data
+
+
+def get_v2_repositories():
+    """
+    Get the current data used for processing requests from the flask request context
+    and format it to display basic information about v2 repository.
+
+    Value corresponding to each key(repo-registry-id) is a dictionary itself
+    with the following format:
+    {'protected': true/false}
+
+    :return: dictionary keyed by repo-registry-ids
+    :rtype: dict
+    """
+    all_repo_data_v2 = get_v2_data().get('repos', {})
+    relevant_repo_data = {}
+    for repo_registry_id, repo in all_repo_data_v2.items():
+        relevant_repo_data[repo_registry_id] = {'protected': repo.protected}
 
     return relevant_repo_data
 

--- a/crane/views/crane.py
+++ b/crane/views/crane.py
@@ -10,15 +10,33 @@ section = Blueprint('crane', __name__, url_prefix='/crane')
 
 
 @section.route('/repositories')
+@section.route('/repositories/v1')
 def repositories():
     """
-    Returns a json document containing a dictionary of repositories served by crane
+    Returns a json document containing a dictionary of v1 repositories served by crane
     and keyed by the repo-registry-id which is unique for each repository.
 
     :return:    json string containing a list of docker repositories
     :rtype:     basestring
     """
     repos_json = app_util.get_repositories()
+    if 'Accept' in request.headers and request.headers['Accept'] == 'application/json':
+        response = current_app.make_response(json.dumps(repos_json))
+        response.headers['Content-Type'] = 'application/json'
+        return response
+    return render_template("repositories.html", repos_json=repos_json)
+
+
+@section.route('/repositories/v2')
+def repositories_v2():
+    """
+    Returns a json document containing a dictionary of v2 repositories served by crane
+    and keyed by the repo-registry-id which is unique for each repository.
+
+    :return:    json string containing a list of docker repositories
+    :rtype:     basestring
+    """
+    repos_json = app_util.get_v2_repositories()
     if 'Accept' in request.headers and request.headers['Accept'] == 'application/json':
         response = current_app.make_response(json.dumps(repos_json))
         response.headers['Content-Type'] = 'application/json'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,11 +170,13 @@ These files are produced by a publish action in
 Crane Admin
 -----------
 
-A list of images served by Crane can be obtained by opening ``/crane/repositories`` in a web
-browser or with ``curl``. The default Apache configuration distributed with Crane restricts access
-to this URL from ``localhost`` only; when accessed from a web browser, repositories and their
-images are listed on a web page. This URL accepts an optional "Accept" header. When
-"application/json" is specified, the application responds with JSON. Here is an example:
+A list of repositories served by Crane can be obtained by opening ``/crane/repositories``
+or ``/crane/repositories/v1`` for repositories with v1 content and ``/crane/repositories/v2``
+for repositories with v2 content in a web browser or with ``curl``. The default Apache
+configuration distributed with Crane restricts access to this URL from ``localhost`` only;
+when accessed from a web browser, repositories and some basuc info is listed on a web page.
+This URL accepts an optional "Accept" header. When "application/json" is specified, the application
+responds with JSON. Here is an example of repository with v1 content:
 
 .. code-block:: json
 


### PR DESCRIPTION
closes #2723
https://pulp.plan.io/issues/2723

Based on current metadata json published for Crane it would be impossible to display content of the repositories ( without changing publish steps again or making some queries to DB). Maximum what we could do is to display just the name of the repo and state of its protection.

I am not very happy about the current solution but given the historical background we whether:
1. update publish steps, bump redirect file version and polulate json file with more info so then we could use it in this endpoint. Does not worth imho.
2. Do the way this PR does
3. Don't make any changes to the code and just update the docs and claim that this endpoint will show just v1 content.