### PR TITLE
Add endpoint /crane/repositories/v2 to display v2 repositories.

### DIFF
--- a/crane/app_util.py
+++ b/crane/app_util.py
@@ -172,7 +172,7 @@ def get_repositories():
     """
     Get the current data used for processing requests from the flask request context
     and format it to display basic information about image ids and tags associated
-    with each repository.
+    with each v1 repository.
 
     Value corresponding to each key(repo-registry-id) is a dictionary itself
     with the following format:
@@ -191,6 +191,26 @@ def get_repositories():
         relevant_repo_data[repo_registry_id] = {'image_ids': image_ids,
                                                 'tags': json.loads(repo.tags_json),
                                                 'protected': repo.protected}
+
+    return relevant_repo_data
+
+
+def get_v2_repositories():
+    """
+    Get the current data used for processing requests from the flask request context
+    and format it to display basic information about v2 repository.
+
+    Value corresponding to each key(repo-registry-id) is a dictionary itself
+    with the following format:
+    {'protected': true/false}
+
+    :return: dictionary keyed by repo-registry-ids
+    :rtype: dict
+    """
+    all_repo_data_v2 = get_v2_data().get('repos', {})
+    relevant_repo_data = {}
+    for repo_registry_id, repo in all_repo_data_v2.items():
+        relevant_repo_data[repo_registry_id] = {'protected': repo.protected}
 
     return relevant_repo_data
 

--- a/crane/templates/layout.html
+++ b/crane/templates/layout.html
@@ -13,7 +13,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="../dist/img/apple-touch-icon-114-precomposed.png">
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="../dist/img/apple-touch-icon-72-precomposed.png">
     <link rel="apple-touch-icon-precomposed" href="../dist/img/apple-touch-icon-57-precomposed.png">
-    <link href="../static/css/patternfly.min.css" rel="stylesheet" media="screen, print">
+    <link href="{{url_for('static', filename='css/patternfly.min.css')}}" rel="stylesheet" media="screen, print">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
     <script src="../components/html5shiv/dist/html5shiv.min.js"></script>
@@ -38,6 +38,9 @@
         <ul class="nav navbar-nav navbar-primary">
           <li class="active">
             <a href="/crane/repositories" class="active">Repositories</a>
+          </li>
+          <li class="active">
+            <a href="/crane/repositories/v2" class="active">Repositories v2</a>
           </li>
         </ul>
       </div>

--- a/crane/templates/repositories.html
+++ b/crane/templates/repositories.html
@@ -1,15 +1,17 @@
 {# _crane/templates/repositories.html_ #}
 {% extends "layout.html" %}
-{% block title %}Repositories {% endblock %}
+{% block title %} {{repo_type}} Repositories {% endblock %}
 {% block body %}
     <div class="container-fluid">
       <div class="row">
         <div class="col-md-12">
+          {% if repos_json is defined %}
           {% for repo_name, repo_info in repos_json.iteritems() %} 
           <div>
           <h3><strong>Repository id: </strong>{{ repo_name }}</h3>
             <h3><strong>Protected: </strong>{{ repo_info.protected }}</h3>
           </div>
+          {% if repo_info.tags is defined %}
       <table class="datatable table table-striped table-bordered">
         <thead>
           <tr>
@@ -30,8 +32,10 @@
           {% endfor %}
         </tbody>
       </table>
+	  {% endif %}
             <hr>
       {% endfor %}
+	  {% endif %}
         </div><!-- /col -->
       </div><!-- /row -->
     </div><!-- /container -->

--- a/crane/views/crane.py
+++ b/crane/views/crane.py
@@ -10,9 +10,10 @@ section = Blueprint('crane', __name__, url_prefix='/crane')
 
 
 @section.route('/repositories')
+@section.route('/repositories/v1')
 def repositories():
     """
-    Returns a json document containing a dictionary of repositories served by crane
+    Returns a json document containing a dictionary of v1 repositories served by crane
     and keyed by the repo-registry-id which is unique for each repository.
 
     :return:    json string containing a list of docker repositories
@@ -23,4 +24,21 @@ def repositories():
         response = current_app.make_response(json.dumps(repos_json))
         response.headers['Content-Type'] = 'application/json'
         return response
-    return render_template("repositories.html", repos_json=repos_json)
+    return render_template("repositories.html", repos_json=repos_json, repo_type='v1')
+
+
+@section.route('/repositories/v2')
+def repositories_v2():
+    """
+    Returns a json document containing a dictionary of v2 repositories served by crane
+    and keyed by the repo-registry-id which is unique for each repository.
+
+    :return:    json string containing a list of docker repositories
+    :rtype:     basestring
+    """
+    repos_json = app_util.get_v2_repositories()
+    if 'Accept' in request.headers and request.headers['Accept'] == 'application/json':
+        response = current_app.make_response(json.dumps(repos_json))
+        response.headers['Content-Type'] = 'application/json'
+        return response
+    return render_template("repositories.html", repos_json=repos_json, repo_type='v2')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,11 +170,13 @@ These files are produced by a publish action in
 Crane Admin
 -----------
 
-A list of images served by Crane can be obtained by opening ``/crane/repositories`` in a web
-browser or with ``curl``. The default Apache configuration distributed with Crane restricts access
-to this URL from ``localhost`` only; when accessed from a web browser, repositories and their
-images are listed on a web page. This URL accepts an optional "Accept" header. When
-"application/json" is specified, the application responds with JSON. Here is an example:
+A list of repositories served by Crane can be obtained by opening ``/crane/repositories``
+or ``/crane/repositories/v1`` for repositories with v1 content and ``/crane/repositories/v2``
+for repositories with v2 content in a web browser or with ``curl``. The default Apache
+configuration distributed with Crane restricts access to this URL from ``localhost`` only;
+when accessed from a web browser, repositories and some basuc info is listed on a web page.
+This URL accepts an optional "Accept" header. When "application/json" is specified, the application
+responds with JSON. Here is an example of repository with v1 content:
 
 .. code-block:: json
 

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -6,7 +6,7 @@ import unittest2 as unittest
 
 from crane import app_util
 from crane import exceptions
-from crane.data import V1Repo
+from crane.data import V1Repo, V2Repo, V3Repo
 import demo_data
 
 from views import base
@@ -276,4 +276,22 @@ class TestValidateGetRepositories(unittest.TestCase):
     def test_get_repositories_empty(self, mock_get_data):
         mock_get_data.return_value = {'repos': {}}
         ret = app_util.get_repositories()
+        self.assertEqual(ret, {})
+
+
+class TestValidateGetV2Repositories(unittest.TestCase):
+
+    @mock.patch('crane.app_util.get_v2_data')
+    def test_get_v2_repositories(self, mock_get_v2_data):
+        repo = V2Repo(url="", url_path="", protected=True)
+        repo2 = V3Repo(url="", url_path="", schema2_data=[], protected=False)
+        mock_get_v2_data.return_value = {'repos': {'test-repo': repo, 'test-repo2': repo2}}
+        ret = app_util.get_v2_repositories()
+        self.assertEqual(ret['test-repo']['protected'], True)
+        self.assertEqual(ret['test-repo2']['protected'], False)
+
+    @mock.patch('crane.app_util.get_v2_data')
+    def test_get_v2_repositories_empty(self, mock_get_v2_data):
+        mock_get_v2_data.return_value = {'repos': {}}
+        ret = app_util.get_v2_repositories()
         self.assertEqual(ret, {})

--- a/tests/views/test_repositories.py
+++ b/tests/views/test_repositories.py
@@ -30,6 +30,33 @@ class TestRepository(base.BaseCraneAPITest):
         self.assertEqual(response_data['qux'], expected_data['qux'])
         self.assertEqual(response_data['redhat/foo'], expected_data['redhat/foo'])
 
+    def test_repositories_v2_json(self):
+        response = self.test_client.get('/crane/repositories/v2',
+                                        headers={'Accept': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json')
+
+        response_data = json.loads(response.data)
+        expected_data = {'registry': {'protected': False},
+                         'v2/bar': {'protected': False},
+                         'redhat/foo': {'protected': False}}
+
+        self.assertEqual(response_data['registry'], expected_data['registry'])
+        self.assertEqual(response_data['v2/bar'], expected_data['v2/bar'])
+        self.assertEqual(response_data['redhat/foo'], expected_data['redhat/foo'])
+
+    def test_repositories_v2_html(self):
+        response = self.test_client.get('/crane/repositories/v2')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'text/html; charset=utf-8')
+        expected_data = {'registry': {'protected': False},
+                         'v2/bar': {'protected': False},
+                         'redhat/foo': {'protected': False}}
+
+        # Assert that all repo ids in json are present in the HTML
+        for repo_id, repo_info in expected_data.iteritems():
+            self.assertTrue(response.data.find(repo_id))
+
     def test_repositories_html(self):
         response = self.test_client.get('/crane/repositories')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
closes #2723
https://pulp.plan.io/issues/2723

Based on current metadata json published for Crane it would be impossible to display content of the repositories ( without changing publish steps again or making some queries to DB). Maximum what we could do is to display just the name of the repo and state of its protection.

I am not very happy about the current solution but given the historical background we whether:

    update publish steps, bump redirect file version and polulate json file with more info so then we could use it in this endpoint. Does not worth imho.
    Do the way this PR does
    Don't make any changes to the code and just update the docs and claim that this endpoint will show just v1 content.
