### PR TITLE
Improved logging during data load

### DIFF
--- a/crane/data.py
+++ b/crane/data.py
@@ -174,6 +174,7 @@ def load_all(app):
         # load data from each file
         for metadata_file_path in paths:
             try:
+                logger.debug('loading: %s' % metadata_file_path)
                 repo_id, repo_tuple, image_ids = load_from_file(metadata_file_path)
             except Exception, e:
                 logger.error('skipping current metadata load: %s' % str(e))
@@ -196,5 +197,6 @@ def load_all(app):
         v2_response_data = {
             'repos': v2_repos
         }
+        logger.info('finished loading metadata')
     except Exception, e:
         logger.error('aborting metadata load: %s' % str(e))


### PR DESCRIPTION
crane previously logged only that it was about to start loading
metadata, and did not log when it completed.  Log both when it
completed, and (at debug level) log each file loaded.

This is important for us as we've had problems with delays
before data became available in crane, and without the log at
completion:

- we can't measure the performance of crane's data loading, so we can't
  judge if the performance is acceptable

- we can't know with certainty at what time published data has become
  available, so we can't effectively debug issues with missing data